### PR TITLE
Update plugin to latest API

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -33,7 +33,7 @@ static anyID followerId;
 #define _strcpy(dest, destSize, src) { strncpy(dest, src, destSize-1); (dest)[destSize-1] = '\0'; }
 #endif
 
-#define PLUGIN_API_VERSION 23
+#define PLUGIN_API_VERSION 26
 
 #define PATH_BUFSIZE 512
 #define COMMAND_BUFSIZE 128
@@ -81,7 +81,7 @@ const char* ts3plugin_name() {
 
 /* Plugin version */
 const char* ts3plugin_version() {
-	return "1.1";
+        return "1.2";
 }
 
 /* Plugin API version. Must be the same as the clients API major version, else the plugin fails to load. */


### PR DESCRIPTION
## Summary
- update plugin API version to 26
- bump plugin version to 1.2

## Testing
- `gcc -c -Iinclude src/plugin.c -o plugin.o`

------
https://chatgpt.com/codex/tasks/task_e_685993dac79c8323888febf65d40941c